### PR TITLE
Adding render on save and template fixes.

### DIFF
--- a/app/routes/template_routes.py
+++ b/app/routes/template_routes.py
@@ -16,6 +16,7 @@ from app.helpers.helpers import (
     list_files,
 )
 from app.routes import bp
+from app.ssp_tools.createfiles import create_files
 from app.ssp_tools.helpers.toolkitconfig import ToolkitConfig
 
 
@@ -104,6 +105,7 @@ def template_save_file():
     file_path: Path = ssp_base.joinpath(filename)
     with open(file_path, "w") as f:
         f.write(content)
+    create_files(to_render=file_path.as_posix())
 
     flash("File saved successfully", "status")
     return redirect(request.referrer or "/")

--- a/app/templates/rendered/rendered_file.html
+++ b/app/templates/rendered/rendered_file.html
@@ -7,9 +7,23 @@
     <section>
         <a
             class="outline wide"
-            href="{{ url_for('routes.toolkit_render_files', subpath=file_path) }}"
+            {% if file_path.endswith(".yaml") %}
+            href="{{
+                url_for(
+                    'routes.template_edit_file',
+                    subpath=file_path
+                )
+            }}"
+            {% else %}
+            href="{{
+                url_for(
+                    'routes.template_edit_file',
+                    subpath=file_path + ".j2"
+                )
+            }}"
+            {% endif %}
             role="button"
-        >Render file</a>
+        >Edit file</a>
     </section>
     <section>
         {{ content | safe }}

--- a/app/templates/rendered/rendered_file_list.html
+++ b/app/templates/rendered/rendered_file_list.html
@@ -20,7 +20,12 @@
                         <a href="{{ url_for('routes.rendered_path_view', subpath=dir) }}">{{ parts | last }}</a>
                     </td>
                     <td>
-                        <a href="{{ url_for('routes.toolkit_render_files', subpath=dir) }}">Render</a>
+                        <a href="{{
+                            url_for(
+                                'routes.toolkit_render_files',
+                                subpath=dir | replace("rendered", "templates")
+                            )
+                        }}">Re-render</a>
                     </td>
                 </tr>
             {% endfor %}
@@ -44,7 +49,28 @@
                         <a href="{{ url_for('routes.rendered_path_view', subpath=file) }}">{{ parts | last }}</a>
                     </td>
                     <td>
-                        <a href="{{ url_for('routes.toolkit_render_files', subpath=file) }}">Render</a>
+                    {% if file.endswith(".yaml") %}
+                        <a href="{{
+                            url_for(
+                                'routes.template_edit_file',
+                                subpath=file | replace("rendered", "templates")
+                            )
+                        }}">Edit</a>
+                    {% else %}
+                        <a href="{{
+                            url_for(
+                                'routes.template_edit_file',
+                                subpath=file | replace('rendered', 'templates') + ".j2"
+                            )
+                        }}">Edit</a>
+                    {% endif %}
+                    </td>
+                    <td>
+                        <a href="{{
+                            url_for('routes.toolkit_render_files',
+                                subpath=file | replace('rendered', 'templates')
+                            )
+                        }}">Re-render</a>
                     </td>
                     <td>
                         <a href="{{ url_for('routes.toolkit_export_files', subpath=file) }}">Export</a>

--- a/app/templates/templates/template_editor.html
+++ b/app/templates/templates/template_editor.html
@@ -14,11 +14,6 @@
         <h3>Editing: {{ filename }}</h3>
     </article>
     <section>
-        <a
-            class="outline wide"
-            href="{{ url_for('routes.toolkit_render_files', subpath=filename) }}"
-            role="button"
-        >Render file</a>
         <textarea id="yamlEditor">{{ content }}</textarea>
         <button id="saveButton" type="submit">Save</button>
     </section>


### PR DESCRIPTION
# 📝 One-line Summary

This PR adds rendering of template files when the template is saved.

The PR also addresses incorrect links to render templates from the within the `/rendered` directory and adds and edit link to the `rendered` pages.

The PR removes the `Render` button from the file edit page since files are rendered on save.

> **Issue:** closes #53 

---

## 📖 Description

*A brief summary of the purpose and scope of this pull request. What problem does it solve or improve? Why is it needed now?*

---

## 🔧 Type of Change

*Indicate all that apply:*

* [ ] 🆕 New feature (adds new functionality)
* [ ] 🐛 Bug fix (non-breaking fix for a known issue)

---

## ✅ Tasks to Complete

*Checklist of work being delivered in this PR:*

* [ ] Adding render on save functionality
* [ ] Correcting render links on `/rendered` pages
* [ ] Changing render button to edit button on rendered file view
* [ ] Removing render button from file edit page

---

## 👀 Review Checklist

*For reviewers to verify before approving:*

* [ ] Edit a template and save, you should see `Creating file: rendered...` message
* [ ] Go to any page under `/rendered/` and click on the `Re-render` button you should see the same message
* [ ] Go to any file view under /rendered/` you should see an `Edit` button at the top of the page
* [ ] You should not see the `Render` button on the file edit view.

---


